### PR TITLE
Correção no Link da DevParaná 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Para contribuir, você precisa adicionar as seguintes informações: data, nome 
 
 ### Março
 
-* 11: [DevParaná Conf](https://www.devleaders.com.br/) - *DevParaná*
+* 11: [DevParaná Conf](https://www.devparana.org/) - *DevParaná*
 
 ### Abril
 


### PR DESCRIPTION
Como não tem link do evento 2023, coloquei o link da organização.






Para os bons olhos DevLeaders não é DevParaná. 