### PR TITLE
Adiciona Python Brasil

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Para contribuir, você precisa adicionar as seguintes informações: data, nome 
 
 ### Outubro
 
-* 22/10 - 05/11: [Python Brasil 2023](https://2023.pythonbrasil.org.br/) - **Caxias do Sul / RS**
+* 30/10 - 05/11: [Python Brasil 2023](https://2023.pythonbrasil.org.br/) - **Caxias do Sul / RS**
 
 ### TBA: To Be Announced
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Para contribuir, você precisa adicionar as seguintes informações: data, nome 
 
 ### Outubro
 
+* 22/10 - 05/11: [Python Brasil 2023](https://2023.pythonbrasil.org.br/) - **Caxias do Sul / RS**
 
 ### TBA: To Be Announced
 


### PR DESCRIPTION
Adicionando o evento Python Brasil 2023 à lista. 

Este evento é uma conferência anual para a comunidade Python no Brasil, e reúne desenvolvedores, entusiastas e especialistas em uma ampla gama de tópicos relacionados ao Python. Este evento de três dias é conhecido por suas palestras inspiradoras, tutoriais práticos e workshops envolventes, além de oportunidades para estabelecer contatos e colaborar com outros desenvolvedores.

Abaixo, seguem as informações do evento:

**Nome**: Python Brasil 2023
**Data**: 30 de Outubro de 2023 a 05 de Novembro de 2023
**Local**: Caxias do Sul / RS
**Site**: [https://2023.pythonbrasil.org.br](https://2023.pythonbrasil.org.br/)