### PR TITLE
Mudança nas datas da GambiConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ Para contribuir, você precisa adicionar as seguintes informações: data, nome 
 ### Novembro
 <!-- NOVEMBRO:START -->
 * 09 a 11/11: [The Developer's Life Weekend](https://weekend.developerslife.tech/) - **Campo Mourão-PR** ![híbrido](https://img.shields.io/static/v1?label=&message=h%C3%ADbrido&color=blue)
+ * 25/11 e 26/11: [Gambiconf](https://gambiconf.dev/) - **São Paulo / SP** ![híbrido](https://img.shields.io/static/v1?label=&message=h%C3%ADbrido&color=blue)
 <!-- NOVEMBRO:END -->
 
 ### Dezembro
 <!-- DEZEMBRO:START -->
- * 02/12 e 03/12: [Gambiconf](https://gambiconf.dev/) - **São Paulo / SP**
 <!-- DEZEMBRO:END -->
 
 


### PR DESCRIPTION
Vamos alterar as datas da GambiConf para Novembro, também aproveitei para marcar que o evento será híbrido (Presencial na USP - Campus Butantã, mas com transmissão online).