### PR TITLE
Inclusão do evento "Hacktudo - RJ"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Para contribuir, você precisa adicionar as seguintes informações: data, nome 
 * 14: [Ecossistema Mobile 2023](https://www.eventbrite.com/e/ecossistema-mobile-tickets-699686811087?aff=oddtdtcreator) - **Florianópolis / SC** ![híbrido](https://img.shields.io/static/v1?label=&message=h%C3%ADbrido&color=blue)
 * 14/10 - 14/10: [Front-End Day - Fortaleza 2023](https://www.frontendday.com.br/) - **Fortaleza / CE**
 * 21/10 - 21/10: [Big Data Brazil Experience 2023](https://www.sympla.com.br/evento/big-data-brazil-experience-2023/1764670?gclid=CjwKCAjwg-GjBhBnEiwAMUvNWyjIP4h5lXM4nWTjdrTpnreUQceCoxWKtmHpsiY1fRnXO_ayb_yjyBoCcz8QAvD_BwE) - **São Paulo / RS**
+* 26/10 a 29/10: [HACKTUDO - Festival de cultura digital](https://www.hacktudo.com.br/) - **Cidade das Artes / RJ** ![presencial](https://img.shields.io/static/v1?label=&message=presencial&color=darkblue)
 * 28/10 - 28/10: [codecon<feature>](https://www.codecon.dev/feature) - **Florianopolis / SC**
 * 30/10 - 05/11: [Python Brasil 2023](https://2023.pythonbrasil.org.br/) - **Caxias do Sul / RS**
 <!-- OUTUBRO:END -->


### PR DESCRIPTION
Adicionado o evento  "HACKCONFERENCE - HACKTUDO 2023" que vai ser realizado na Cidade das Artes, Rio de Janeiro - RJ entre os dias 26/10 e 29/10.